### PR TITLE
Fix notebook links in `index.md`

### DIFF
--- a/notebooks/en/index.md
+++ b/notebooks/en/index.md
@@ -7,11 +7,11 @@ applications and solving various machine learning tasks using open-source tools 
 
 Check out the recently added notebooks: 
 
-- [Simple RAG for GitHub issues using Hugging Face Zephyr and LangChain](rag_zephyr_langchain)
-- [Embedding multimodal data for similarity search using 🤗 transformers, 🤗 datasets and FAISS](faiss_with_hf_datasets_and_clip)
-- [Fine-tuning a Code LLM on Custom Code on a single GPU](fine_tuning_code_llm_on_single_gpu)
-- [RAG Evaluation Using Synthetic data and LLM-As-A-Judge](rag_evaluation)
-- [Advanced RAG on HuggingFace documentation using LangChain](advanced_rag)
+- [Simple RAG for GitHub issues using Hugging Face Zephyr and LangChain](rag_zephyr_langchain.ipynb)
+- [Embedding multimodal data for similarity search using 🤗 transformers, 🤗 datasets and FAISS](faiss_with_hf_datasets_and_clip.ipynb)
+- [Fine-tuning a Code LLM on Custom Code on a single GPU](fine_tuning_code_llm_on_single_gpu.ipynb)
+- [RAG Evaluation Using Synthetic data and LLM-As-A-Judge](rag_evaluation.ipynb)
+- [Advanced RAG on HuggingFace documentation using LangChain](advanced_rag.ipynb)
 
 You can also check out the notebooks in the cookbook's [GitHub repo](https://github.com/huggingface/cookbook).
 


### PR DESCRIPTION
# What does this PR do?

Add the `.ipynb` extension in links in `notebooks/en/index.md`. 
As of now clicking any of the links returns a 404, this PR fixes the issue.

## Who can review?

@MKhalusova