### PR TITLE
Update index.md

### DIFF
--- a/notebooks/en/index.md
+++ b/notebooks/en/index.md
@@ -18,7 +18,7 @@ Check out the recently added notebooks:
 - [RAG Evaluation Using Synthetic data and LLM-As-A-Judge](rag_evaluation)
 - [Advanced RAG on HuggingFace documentation using LangChain](advanced_rag)
 
-You can also check out the notebooks in the cookbook's [GitHub repo](https://github.com/huggingface/cookbook.ipynb).
+You can also check out the notebooks in the cookbook's [GitHub repo](https://github.com/huggingface/cookbook).
 
 ## Contributing
 


### PR DESCRIPTION
# What does this PR do?

This PR corrects an incorrect GitHub repository link found in the Hugging Face Cookbook documentation. The current link leads to a 404 page, which can hinder the user experience by preventing access to the intended resource. By updating this link, I ensure users have direct and error-free access to the cookbook's GitHub repository.

Fixes the issue where the GitHub link in the `cookbook/notebooks/en/index.md` file is directing to a non-existent page (`https://github.com/huggingface/cookbook.ipynb`) instead of the correct repository (`https://github.com/huggingface/cookbook`).

## Changes

- Updated the GitHub link in `cookbook/notebooks/en/index.md` from `https://github.com/huggingface/cookbook.ipynb` to `https://github.com/huggingface/cookbook`.
## Who can review?

@MKhalusova

