### PR TITLE
Fix/broken links in Notebooks index.md

### DIFF
--- a/notebooks/en/index.md
+++ b/notebooks/en/index.md
@@ -7,17 +7,17 @@ applications and solving various machine learning tasks using open-source tools 
 
 Check out the recently added notebooks:
 
-- [Building A RAG Ebook "Librarian" Using LlamaIndex](rag_llamaindex_librarian)
-- [Stable Diffusion Interpolation](stable_diffusion_interpolation)
-- [Building A RAG System with Gemma, MongoDB and Open Source Models](rag_with_hugging_face_gemma_mongodb)
-- [Prompt Tuning with PEFT Library](prompt_tuning_peft)
-- [Migrating from OpenAI to Open LLMs Using TGI's Messages API](tgi_messages_api_demo)
-- [Automatic Embeddings with TEI through Inference Endpoints](automatic_embedding_tei_inference_endpoints)
-- [Simple RAG for GitHub issues using Hugging Face Zephyr and LangChain](rag_zephyr_langchain)
-- [Embedding multimodal data for similarity search using 🤗 transformers, 🤗 datasets and FAISS](faiss_with_hf_datasets_and_clip)
-- [Fine-tuning a Code LLM on Custom Code on a single GPU](fine_tuning_code_llm_on_single_gpu)
-- [RAG Evaluation Using Synthetic data and LLM-As-A-Judge](rag_evaluation)
-- [Advanced RAG on HuggingFace documentation using LangChain](advanced_rag)
+- [Building A RAG Ebook "Librarian" Using LlamaIndex](rag_llamaindex_librarian.ipynb)
+- [Stable Diffusion Interpolation](stable_diffusion_interpolation.ipynb)
+- [Building A RAG System with Gemma, MongoDB and Open Source Models](rag_with_hugging_face_gemma_mongodb.ipynb)
+- [Prompt Tuning with PEFT Library](prompt_tuning_peft.ipynb)
+- [Migrating from OpenAI to Open LLMs Using TGI's Messages API](tgi_messages_api_demo.ipynb)
+- [Automatic Embeddings with TEI through Inference Endpoints](automatic_embedding_tei_inference_endpoints.ipynb)
+- [Simple RAG for GitHub issues using Hugging Face Zephyr and LangChain](rag_zephyr_langchain.ipynb)
+- [Embedding multimodal data for similarity search using 🤗 transformers, 🤗 datasets and FAISS](faiss_with_hf_datasets_and_clip.ipynb)
+- [Fine-tuning a Code LLM on Custom Code on a single GPU](fine_tuning_code_llm_on_single_gpu.ipynb)
+- [RAG Evaluation Using Synthetic data and LLM-As-A-Judge](rag_evaluation.ipynb)
+- [Advanced RAG on HuggingFace documentation using LangChain](advanced_rag.ipynb)
 
 You can also check out the notebooks in the cookbook's [GitHub repo](https://github.com/huggingface/cookbook).
 

--- a/notebooks/zh-CN/index.md
+++ b/notebooks/zh-CN/index.md
@@ -5,12 +5,12 @@
 ## 最新 Notebook
 
 查看最近添加的 Notebook：
-- [通过推理端点使用 TEI 自动嵌入](automatic_embedding_tei_inference_endpoints)
-- [用 Hugging Face Zephyr 和 LangChain 针对 Github issues 构建简单的 RAG](rag_zephyr_langchain)
-- [用 🤗 transformers, 🤗 datasets 和 FAISS 嵌入多模态数据进行相似度搜索](faiss_with_hf_datasets_and_clip)
-- [在单个 GPU 上针对自定义代码微调代码 LLM](fine_tuning_code_llm_on_single_gpu)
-- [使用合成数据和 LLM 作为裁判评估 RAG](rag_evaluation)
-- [使用 LangChain 在 HuggingFace 文档上构建高级 RAG](advanced_rag)
+- [通过推理端点使用 TEI 自动嵌入](automatic_embedding_tei_inference_endpoints.ipynb)
+- [用 Hugging Face Zephyr 和 LangChain 针对 Github issues 构建简单的 RAG](rag_zephyr_langchain.ipynb)
+- [用 🤗 transformers, 🤗 datasets 和 FAISS 嵌入多模态数据进行相似度搜索](faiss_with_hf_datasets_and_clip.ipynb)
+- [在单个 GPU 上针对自定义代码微调代码 LLM](fine_tuning_code_llm_on_single_gpu.ipynb)
+- [使用合成数据和 LLM 作为裁判评估 RAG](rag_evaluation.ipynb)
+- [使用 LangChain 在 HuggingFace 文档上构建高级 RAG](advanced_rag.ipynb)
 
 你还可以在指南 (Cookbook) 的[Github 仓库](https://github.com/huggingface/cookbook)中查看 Notebook。
 


### PR DESCRIPTION
# What does this PR do?

Adds the '.ipynb' suffix to file names used in Markdown links to prevent 404 (not found) errors in the index.md pages for `en` and `cn` versions.

<!--
Thank you for submitting a PR to the Open-source AI cookbook!

Someone will review your PR shortly. They may suggest changes to further improve your contribution. 
If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same 
persons---sometimes notifications get lost.

-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- 

At the moment, please tag @MKhalusova

-->
