### PR TITLE
Update data path in RAG LlamaIndex Notebook

### DIFF
--- a/notebooks/en/rag_llamaindex_librarian.ipynb
+++ b/notebooks/en/rag_llamaindex_librarian.ipynb
@@ -100,10 +100,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!mkdir -p \".test/library/jane-austen\"\n",
-    "!mkdir -p \".test/library/victor-hugo\"\n",
-    "!wget https://www.gutenberg.org/ebooks/1342.epub.noimages -O \".test/library/jane-austen/pride-and-prejudice.epub\"\n",
-    "!wget https://www.gutenberg.org/ebooks/135.epub.noimages -O \".test/library/victor-hugo/les-miserables.epub\""
+    "!mkdir -p \"./test/library/jane-austen\"\n",
+    "!mkdir -p \"./test/library/victor-hugo\"\n",
+    "!wget https://www.gutenberg.org/ebooks/1342.epub.noimages -O \"./test/library/jane-austen/pride-and-prejudice.epub\"\n",
+    "!wget https://www.gutenberg.org/ebooks/135.epub.noimages -O \"./test/library/victor-hugo/les-miserables.epub\""
    ]
   },
   {
@@ -150,7 +150,7 @@
     "from llama_index.core import SimpleDirectoryReader\n",
     "\n",
     "loader = SimpleDirectoryReader(\n",
-    "    input_dir=\"./.test/\",\n",
+    "    input_dir=\"./test/\",\n",
     "    recursive=True,\n",
     "    required_exts=[\".epub\"],\n",
     ")\n",


### PR DESCRIPTION
# What does this PR do?

Updates the data path to not be a hidden folder. LlamaIndex (by default) will exclude hidden folders, causing an error when trying to load data with the current code in the notebook.
