### PR TITLE
fix "check notebook names..." workflow

### DIFF
--- a/.github/workflows/check_notebooks_lowercase.yml
+++ b/.github/workflows/check_notebooks_lowercase.yml
@@ -14,7 +14,7 @@ jobs:
         # Change to the directory where you want to check filenames
         cd notebooks
         # Find files with uppercase characters in their names
-        files=$(find . -type f | grep '[A-Z]' || true)
+        files=$(find . -type f -name '*.ipynb' -exec basename {} \;| grep '[A-Z]' || true)
         if [ -n "$files" ]; then
             echo "The following files are not lowercase:"
             echo "$files"


### PR DESCRIPTION
# What does this PR do?
I noticed that ["Check notebook names are lowercase" workflow usually fails](https://github.com/huggingface/cookbook/actions/workflows/check_notebooks_lowercase.yml)
because it checks the whole file path instead of the filename.
> The following files are not lowercase:
> ./zh-CN/rag_evaluation.ipynb

So I am changing the workflow to check only the filenames of notebooks.

*I tested it locally.*

## Who can review?
@merveenoyan @stevhliu @mishig25
