### PR TITLE
adding torchvision to pip install instructions

### DIFF
--- a/notebooks/en/fine_tuning_vit_custom_dataset.ipynb
+++ b/notebooks/en/fine_tuning_vit_custom_dataset.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install datasets transformers accelerate torch scikit-learn matplotlib wandb"
+    "!pip install datasets transformers accelerate torch torchvision scikit-learn matplotlib wandb"
    ]
   },
   {


### PR DESCRIPTION
required by the line `from torchvision.transforms .....

# What does this PR do?

Add a missing library to the pip install instruction

<!-- 
At the moment, please tag @merveenoyan and @stevhliu.
-->
