### PR TITLE
Update vector_search_with_hub_as_backend.ipynb

### DIFF
--- a/notebooks/en/vector_search_with_hub_as_backend.ipynb
+++ b/notebooks/en/vector_search_with_hub_as_backend.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's load the [ai-blueprint/fineweb-bbc-news](https://huggingface.co/datasets/ai-blueprint/imdb) dataset from the Hub. "
+    "Now, let's load the [ai-blueprint/fineweb-bbc-news](https://huggingface.co/datasets/ai-blueprint/fineweb-bbc-news) dataset from the Hub. "
    ]
   },
   {


### PR DESCRIPTION
Fixed broken link to the bbc-news dataset in 'Vector Search on Hugging Face with the Hub as Backend' notebook

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

@merveenoyan and @stevhliu.

