### PR TITLE
`ToolCallingAgent`: Unexpected keyword argument 'verbose'

### DIFF
--- a/notebooks/en/agent_rag.ipynb
+++ b/notebooks/en/agent_rag.ipynb
@@ -238,7 +238,7 @@
     "\n",
     "retriever_tool = RetrieverTool(vectordb)\n",
     "agent = ToolCallingAgent(\n",
-    "    tools=[retriever_tool], model=model, verbose=True\n",
+    "    tools=[retriever_tool], model=model\n",
     ")"
    ]
   },


### PR DESCRIPTION
Tested on `smolagents==1.9.2`

Error message:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 4
      1 model = HfApiModel()  # model_id="meta-llama/Llama-3.1-70B-Instruct")
      3 retriever_tool = RetrieverTool(vectordb=vectordb)
----> 4 agent = ToolCallingAgent(tools=[retriever_tool], model=model, verbose=True)
      5 agent.visualize()

File ~/repos/hf_nlp_course/venv/lib/python3.11/site-packages/smolagents/agents.py:1051, in ToolCallingAgent.__init__(self, tools, model, prompt_templates, planning_interval, **kwargs)
   1040 def __init__(
   1041     self,
   1042     tools: List[Tool],
   (...)
   1046     **kwargs,
   1047 ):
   1048     prompt_templates = prompt_templates or yaml.safe_load(
   1049         importlib.resources.files("smolagents.prompts").joinpath("toolcalling_agent.yaml").read_text()
   1050     )
-> 1051     super().__init__(
   1052         tools=tools,
   1053         model=model,
   1054         prompt_templates=prompt_templates,
   1055         planning_interval=planning_interval,
   1056         **kwargs,
   1057     )

TypeError: MultiStepAgent.__init__() got an unexpected keyword argument 'verbose'
```

# What does this PR do?

<!--
Thank you for submitting a PR to the Open-source AI cookbook!

Someone will review your PR shortly. They may suggest changes to further improve your contribution. 
If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same 
persons---sometimes notifications get lost.

-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- 
At the moment, please tag @merveenoyan and @stevhliu.
-->
