### PR TITLE
`tokenizer` -> `processor` in trl trainers init

### DIFF
--- a/notebooks/en/fine_tune_chatbot_docs_synthetic.ipynb
+++ b/notebooks/en/fine_tune_chatbot_docs_synthetic.ipynb
@@ -4799,7 +4799,7 @@
         "\n",
         "trainer = SFTTrainer(\n",
         "    model = model,\n",
-        "    tokenizer = tokenizer,\n",
+        "    processing_class = tokenizer,\n",
         "    train_dataset = dataset,\n",
         "    eval_dataset = None, # Can set up evaluation!\n",
         "    args = SFTConfig(\n",

--- a/notebooks/en/fine_tuning_granite_vision_sft_trl.ipynb
+++ b/notebooks/en/fine_tuning_granite_vision_sft_trl.ipynb
@@ -844,7 +844,7 @@
     "    train_dataset=train_dataset,\n",
     "    data_collator=collate_fn,\n",
     "    peft_config=peft_config,\n",
-    "    tokenizer=processor.tokenizer,\n",
+    "    processing_class=processor.tokenizer,\n",
     ")"
    ]
   },

--- a/notebooks/en/fine_tuning_llm_to_generate_persian_product_catalogs_in_json_format.ipynb
+++ b/notebooks/en/fine_tuning_llm_to_generate_persian_product_catalogs_in_json_format.ipynb
@@ -420,7 +420,7 @@
     "    formatting_func=formatting_func,\n",
     "    data_collator=collator,\n",
     "    max_seq_length=max_seq_length,\n",
-    "    tokenizer=tokenizer,\n",
+    "    processing_class=tokenizer,\n",
     "    args=training_arguments,\n",
     "    packing=packing\n",
     ")"

--- a/notebooks/en/fine_tuning_smol_vlm_sft_trl.ipynb
+++ b/notebooks/en/fine_tuning_smol_vlm_sft_trl.ipynb
@@ -67,7 +67,7 @@
       "outputs": [],
       "source": [
         "!pip install  -U -q transformers trl datasets bitsandbytes peft accelerate\n",
-        "# Tested with transformers==4.46.3, trl==0.12.1, datasets==3.1.0, bitsandbytes==0.45.0, peft==0.13.2, accelerate==1.1.1"
+        "# Tested with transformers==4.53.0.dev0, trl==0.20.0.dev0, datasets==3.6.0, bitsandbytes==0.46.0, peft==0.15.2, accelerate==1.8.1"
       ]
     },
     {
@@ -871,7 +871,7 @@
         "    eval_dataset=eval_dataset,\n",
         "    data_collator=collate_fn,\n",
         "    peft_config=peft_config,\n",
-        "    tokenizer=processor.tokenizer,\n",
+        "    processing_class=processor.tokenizer,\n",
         ")"
       ]
     },

--- a/notebooks/en/fine_tuning_vlm_dpo_smolvlm_instruct.ipynb
+++ b/notebooks/en/fine_tuning_vlm_dpo_smolvlm_instruct.ipynb
@@ -413,7 +413,7 @@
         "    train_dataset=train_dataset,\n",
         "    eval_dataset=test_dataset,\n",
         "    peft_config=peft_config,\n",
-        "    tokenizer=processor,\n",
+        "    processing_class=processor,\n",
         ")"
       ]
     },

--- a/notebooks/en/fine_tuning_vlm_trl.ipynb
+++ b/notebooks/en/fine_tuning_vlm_trl.ipynb
@@ -69,7 +69,7 @@
       "outputs": [],
       "source": [
         "!pip install  -U -q git+https://github.com/huggingface/transformers.git git+https://github.com/huggingface/trl.git datasets bitsandbytes peft qwen-vl-utils wandb accelerate\n",
-        "# Tested with transformers==4.47.0.dev0, trl==0.12.0.dev0, datasets==3.0.2, bitsandbytes==0.44.1, peft==0.13.2, qwen-vl-utils==0.0.8, wandb==0.18.5, accelerate==1.0.1"
+        "# Tested with transformers==4.53.0.dev0, trl==0.20.0.dev0, datasets==3.6.0, bitsandbytes==0.46.0, peft==0.15.2, qwen-vl-utils==0.0.11, wandb==0.20.1, accelerate==1.8.1"
       ]
     },
     {
@@ -1473,7 +1473,7 @@
         "    eval_dataset=eval_dataset,\n",
         "    data_collator=collate_fn,\n",
         "    peft_config=peft_config,\n",
-        "    tokenizer=processor.tokenizer,\n",
+        "    processing_class=processor.tokenizer,\n",
         ")"
       ]
     },

--- a/notebooks/zh-CN/fine_tuning_llm_to_generate_persian_product_catalogs_in_json_format.ipynb
+++ b/notebooks/zh-CN/fine_tuning_llm_to_generate_persian_product_catalogs_in_json_format.ipynb
@@ -425,7 +425,7 @@
     "    formatting_func=formatting_func,\n",
     "    data_collator=collator,\n",
     "    max_seq_length=max_seq_length,\n",
-    "    tokenizer=tokenizer,\n",
+    "    processing_class=tokenizer,\n",
     "    args=training_arguments,\n",
     "    packing=packing\n",
     ")"

--- a/notebooks/zh-CN/fine_tuning_vlm_trl.ipynb
+++ b/notebooks/zh-CN/fine_tuning_vlm_trl.ipynb
@@ -65,7 +65,7 @@
       "outputs": [],
       "source": [
         "!pip install  -U -q git+https://github.com/huggingface/transformers.git git+https://github.com/huggingface/trl.git datasets bitsandbytes peft qwen-vl-utils wandb accelerate\n",
-        "# Tested with transformers==4.47.0.dev0, trl==0.12.0.dev0, datasets==3.0.2, bitsandbytes==0.44.1, peft==0.13.2, qwen-vl-utils==0.0.8, wandb==0.18.5, accelerate==1.0.1"
+        "# Tested with transformers==4.53.0.dev0, trl==0.20.0.dev0, datasets==3.6.0, bitsandbytes==0.46.0, peft==0.15.2, qwen-vl-utils==0.0.11, wandb==0.20.1, accelerate==1.8.1"
       ]
     },
     {
@@ -1470,7 +1470,7 @@
         "    eval_dataset=eval_dataset,\n",
         "    data_collator=collate_fn,\n",
         "    peft_config=peft_config,\n",
-        "    tokenizer=processor.tokenizer,\n",
+        "    processing_class=processor.tokenizer,\n",
         ")"
       ]
     },


### PR DESCRIPTION
# What does this PR do?

For TRL trainers, changed `tokenizer` to `processor` in init since it's no longer accepted.

Fixes #305
Related to https://github.com/huggingface/trl/pull/2162 and https://github.com/huggingface/transformers/pull/32385

## Who can review?

@merveenoyan and @stevhliu.

