### PR TITLE
Update rag_evaluation.ipynb

### DIFF
--- a/notebooks/en/rag_evaluation.ipynb
+++ b/notebooks/en/rag_evaluation.ipynb
@@ -1127,7 +1127,7 @@
     "\n",
     "To this end, __we setup a judge agent__. ⚖️🤖\n",
     "\n",
-    "Out of [the different RAG evaluation metrics](https://docs.ragas.io/en/latest/concepts/metrics/index.html), we choose to focus only on faithfulness since it the best end-to-end metric of our system's performance.\n",
+    "Out of [the different RAG evaluation metrics](https://docs.ragas.io/en/latest/concepts/metrics/index.html), we choose to focus only on faithfulness since it is the best end-to-end metric of our system's performance.\n",
     "\n",
     "> We use GPT4 as a judge for its empirically good performance, but you could try with other models such as [kaist-ai/prometheus-13b-v1.0](https://huggingface.co/kaist-ai/prometheus-13b-v1.0) or [BAAI/JudgeLM-33B-v1.0](https://huggingface.co/BAAI/JudgeLM-33B-v1.0).\n",
     "\n",


### PR DESCRIPTION
Fixing a grammatical error. It's missing the word "is" after "since it"

# What does this PR do?

This PR fixes a minor grammatical error in the RAG evaluation metrics section. The sentence was missing the word "is" after "since it", which made it grammatically incorrect.

**Before:** "Out of the different RAG evaluation metrics, we choose to focus only on faithfulness since it the best end-to-end metric of our system's performance."

**After:** "Out of the different RAG evaluation metrics, we choose to focus only on faithfulness since it **is** the best end-to-end metric of our system's performance."

This is a small but important fix that improves the readability and correctness of the documentation.

## Who can review?

@merveenoyan and @stevhliu
