### PR TITLE
Update rag_evaluation.ipynb

### DIFF
--- a/notebooks/en/rag_evaluation.ipynb
+++ b/notebooks/en/rag_evaluation.ipynb
@@ -1127,7 +1127,7 @@
     "\n",
     "To this end, __we setup a judge agent__. ⚖️🤖\n",
     "\n",
-    "Out of [the different RAG evaluation metrics](https://docs.ragas.io/en/latest/concepts/metrics/index.html), we choose to focus only on faithfulness since it the best end-to-end metric of our system's performance.\n",
+    "Out of [the different RAG evaluation metrics](https://docs.ragas.io/en/latest/concepts/metrics/index.html), we choose to focus only on Answer Correctness since it is the best end-to-end metric of our system's performance.\n",
     "\n",
     "> We use GPT4 as a judge for its empirically good performance, but you could try with other models such as [kaist-ai/prometheus-13b-v1.0](https://huggingface.co/kaist-ai/prometheus-13b-v1.0) or [BAAI/JudgeLM-33B-v1.0](https://huggingface.co/BAAI/JudgeLM-33B-v1.0).\n",
     "\n",


### PR DESCRIPTION
# What does this PR do?

This PR corrects a small error in the text describing the evaluation metric. The original text mentioned faithfulness, but the code and the context of the evaluation are focused on Answer Correctness as the primary end-to-end metric in the article.
This change ensures the explanation accurately reflects the implementation.

Before:
Out of the different RAG evaluation metrics, we choose to focus only on faithfulness since it the best end-to-end metric of our system's performance
After:
Out of the different RAG evaluation metrics, we choose to focus only on Answer Correctness since it is the best end-to-end metric of our system's performance

Who can review?

@merveenoyan @stevhliu
