### PR TITLE
Fix GRPO Reasoning Advanced Reward Tutorial

### DIFF
--- a/notebooks/en/trl_grpo_reasoning_advanced_reward.ipynb
+++ b/notebooks/en/trl_grpo_reasoning_advanced_reward.ipynb
@@ -497,7 +497,7 @@
     "training_args = GRPOConfig(\n",
     "    # Learning parameters optimized for reasoning tasks\n",
     "    learning_rate=5e-6,              # Conservative LR to prevent destabilizing reasoning\n",
-    "    bf16=False",
+    "    bf16=False,",
     "    \n",
     "    # Memory-efficient batch configuration\n",
     "    per_device_train_batch_size=2,   # Small batch for GPU memory constraints\n",


### PR DESCRIPTION
# What does this PR do?
Fixes the notebook to disable `bf16` because the model and lora weights are configured to load in `bf16`
<!-- Remove if not applicable -->

Fixes # (issue)

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.
@stevhliu 
