### PR TITLE
Remove max_prompt_length

### DIFF
--- a/notebooks/en/fine_tuning_llm_grpo_trl.ipynb
+++ b/notebooks/en/fine_tuning_llm_grpo_trl.ipynb
@@ -499,8 +499,7 @@
         "\n",
         "    # Parameters that control de data preprocessing\n",
         "    max_completion_length=64, # default: 256\n",
-        "    num_generations=4, # default: 8\n"
-        "  
+        "    num_generations=4, # default: 8\n",
         "\n",
         "    # Parameters related to reporting and saving\n",
         "    report_to=[\"tensorboard\"],\n",

--- a/notebooks/en/fine_tuning_llm_grpo_trl.ipynb
+++ b/notebooks/en/fine_tuning_llm_grpo_trl.ipynb
@@ -470,9 +470,9 @@
       "source": [
         "### 3.4 Configuring GRPO Training Parameters\n",
         "\n",
-        "Next, let's configure the training parameters for GRPO. We recommend experimenting with the `max_completion_length`, `num_generations`, and `max_prompt_length` parameters (refer to the image at the beginning for details about each of them).\n",
+        "Next, let's configure the training parameters for GRPO. We recommend experimenting with the `max_completion_length`and `num_generations` parameters (refer to the image at the beginning for details about each of them).\n",
         "\n",
-        "To keep things simple, we’ll start by training for just one epoch and reducing the `max_completion_length`, `num_generations`, and `max_prompt_length` from their default values."
+        "To keep things simple, we’ll start by training for just one epoch and reducing the `max_completion_length`and `num_generations`from their default values."
       ],
       "metadata": {
         "id": "qW_3r8T1EtNg"
@@ -499,8 +499,8 @@
         "\n",
         "    # Parameters that control de data preprocessing\n",
         "    max_completion_length=64, # default: 256\n",
-        "    num_generations=4, # default: 8\n",
-        "    max_prompt_length=128, # default: 512\n",
+        "    num_generations=4, # default: 8\n"
+        "  
         "\n",
         "    # Parameters related to reporting and saving\n",
         "    report_to=[\"tensorboard\"],\n",


### PR DESCRIPTION
max_prompt_length is no longer supported in GRPOConfig, Hence Removed it in Config and relavent Documentations

# What does this PR do?

The `max_prompt_length` parameter is no longer supported in `GRPOConfig`. This PR removes it from the `fine_tuning_llm_grpo_trl.ipynb` notebook configuration and relevant documentation to prevent execution errors and confusion for users following the tutorial.

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.
@merveenoyan @stevhliu 

