### PR TITLE
fix: update depricated langchain imports

### DIFF
--- a/notebooks/en/rag_zephyr_langchain.ipynb
+++ b/notebooks/en/rag_zephyr_langchain.ipynb
@@ -420,39 +420,7 @@
         "id": "GYh-HG1l0De5",
         "outputId": "277d8e89-ce9b-4e04-c11b-639ad2645759"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Both `max_new_tokens` (=400) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "<|system|>\n",
-            "Answer the question based on your knowledge. Use the following context to help:\n",
-            "\n",
-            "\n",
-            "\n",
-            "</s>\n",
-            "<|user|>\n",
-            "How do you combine multiple adapters?\n",
-            "</s>\n",
-            "<|assistant|>\n",
-            "\n",
-            " 1. By connecting them all together in a straight line.\n",
-            " 2. By stacking them one on top of another, with each adapter being connected to the previous one.\n",
-            "\n",
-            "The correct way to combine multiple adapters is by stacking them one on top of another, with each adapter being connected to the previous one. This allows for proper connection and ensures that power flows smoothly from one adapter to the next. Connecting them all together in a straight line would not allow for this smooth flow of power. Therefore, option 2 is the correct answer. \n",
-            "\n",
-            "It's important to note that when combining multiple adapters, it's crucial to ensure that they are compatible with each other and have the same voltage and amperage requirements. If any of these factors differ between the adapters, it could result in damage or malfunctioning of the devices plugged into the adapters. Always check compatibility before using multiple adapters together. Additionally, if you're unsure about the specific requirements of your devices, consulting with an electrical professional can be helpful. They can provide guidance on which adapters are suitable for use together and how to connect them properly. Remember, safety should always come first when working with electricity.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "llm_chain.invoke({\"context\":\"\", \"question\": question})"
       ]
@@ -478,55 +446,7 @@
         "id": "FZpNA3o10H10",
         "outputId": "31f9aed3-3dd7-4ff8-d1a8-866794fefe80"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Both `max_new_tokens` (=400) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "<|system|>\n",
-            "Answer the question based on your knowledge. Use the following context to help:\n",
-            "\n",
-            "[Document(id='f6b8fa6a-3c83-415f-993e-f6c5256b872a', metadata={'url': 'https://github.com/huggingface/peft/issues/1802', 'title': 'Issues when switching between multiple adapters LoRAs ', 'creator': 'JhonDan1999', 'created_at': '2024-05-26T19:18:13Z', 'comments': 8, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1802, 'is_pull_request': False}, page_content='The documentation does not mention the need to perform a merge when switching adapters. Additionally, the methods add_adapter, set_adapter, and enable_adapters do not appear to work\\r\\n\\r\\nPlease provide clarification on how to correctly switch between adapters'), Document(id='364a0801-5142-42c3-b1c9-98adb4426532', metadata={'url': 'https://github.com/huggingface/peft/issues/1045', 'title': 'add_weighted_adapter() is unusable, throws error: \"Invalid type <class \\'list\\'> found in target_modules\"', 'creator': 'Vectorrent', 'created_at': '2023-10-22T21:42:32Z', 'comments': 6, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1045, 'is_pull_request': False}, page_content=\"If you can provide any advice, I would greatly appreciate it. I suspect that this is either unsupported and/or not fully-implemented; or, it has something to do with the way I'm attaching adapters. I've tried a bunch of alternate configurations, but I'm not having luck.\\r\\n\\r\\nThanks in advance for any help you might provide.\"), Document(id='e8569043-11a4-4cfe-9cc6-2bfc2a49b8b5', metadata={'url': 'https://github.com/huggingface/peft/issues/2749', 'title': 'Set multiple adapters actively when training', 'creator': 'Yongyi-Liao', 'created_at': '2025-08-21T09:59:25Z', 'comments': 4, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 2749, 'is_pull_request': False}, page_content='I also set multiple adapters actively when training. My code is as following:'), Document(id='5b74065f-066c-4441-9d63-9637890997fb', metadata={'url': 'https://github.com/huggingface/peft/issues/1497', 'title': 'Cannot load adapters from Peft.from_pretrained', 'creator': 'dame-cell', 'created_at': '2024-02-21T13:37:31Z', 'comments': 0, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1497, 'is_pull_request': False}, page_content='### Expected behavior\\r\\n\\r\\nI think I would want the adapters to be downloaded and then I would be able to merge my adapters into one')]\n",
-            "\n",
-            "</s>\n",
-            "<|user|>\n",
-            "How do you combine multiple adapters?\n",
-            "</s>\n",
-            "<|assistant|>\n",
-            "\n",
-            "  To combine multiple adapters, you should use the `PeftModel` class's `merge_adapter` method. This method takes another `PeftModel` instance as an argument and merges its adapter weights into the current model.\n",
-            "\n",
-            "Here is an example of how to use the `merge_adapter` method:\n",
-            "\n",
-            "```python\n",
-            "from peft import PeftModel\n",
-            "\n",
-            "# Assuming you have two PeftModels named model_1 and model_2\n",
-            "model_1 = PeftModel.from_pretrained(\"path/to/model_1\", \"adapter_model\")\n",
-            "model_2 = PeftModel.from_pretrained(\"path/to/model_2\", \"adapter_model\")\n",
-            "\n",
-            "# Merge model_2's adapter weights into model_1\n",
-            "merged_model = model_1.merge_adapter(model_2)\n",
-            "```\n",
-            "\n",
-            "This will update the weights of `model_1` with those from `model_2`, effectively combining them into a single model. Make sure both models are compatible (i.e., they share the same architecture) before merging their adapter weights. \n",
-            "\n",
-            "Note that if you're working with multiple adapters separately and want to apply them individually during inference, you may need to create separate instances of `PeftModel` for each adapter and call `set_adapter` on each instance to activate the corresponding adapter. However, for training purposes, using `merge_adapter` is more appropriate since it allows you to integrate all adapters into a unified model. \n",
-            "\n",
-            "Also, ensure that the adapters being merged are compatible with each other regarding their structure and configuration. If there are differences in the adapter definitions, some parts might not be merged properly. In such cases, you may need to adjust the adapter settings manually after merging. \n",
-            "\n",
-            "For detailed instructions and examples, refer to the official Hugging Face documentation on [Peft](https://huggingface.co/docs/transformers/main_classes/modules#torch.nn.Module). The documentation provides comprehensive guidance on creating, loading, and managing adapters within a PyTorch-based model.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "rag_chain.invoke(question)"
       ]

--- a/notebooks/en/rag_zephyr_langchain.ipynb
+++ b/notebooks/en/rag_zephyr_langchain.ipynb
@@ -454,8 +454,7 @@
         }
       ],
       "source": [
-        "result = llm_chain.invoke({\"context\":\"\", \"question\": question})\n",
-        "print(result)"
+        "llm_chain.invoke({\"context\":\"\", \"question\": question})"
       ]
     },
     {
@@ -529,8 +528,7 @@
         }
       ],
       "source": [
-        "output = rag_chain.invoke(question)\n",
-        "print(output)"
+        "rag_chain.invoke(question)"
       ]
     },
     {

--- a/notebooks/en/rag_zephyr_langchain.ipynb
+++ b/notebooks/en/rag_zephyr_langchain.ipynb
@@ -42,7 +42,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q torch transformers accelerate bitsandbytes transformers sentence-transformers faiss-gpu"
+        "!pip install -q torch transformers accelerate bitsandbytes sentence-transformers faiss-gpu"
       ]
     },
     {
@@ -66,7 +66,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q langchain langchain-community"
+        "!pip install -q langchain langchain-community langchain_text_splitters langchain_huggingface"
       ]
     },
     {
@@ -120,7 +120,7 @@
       },
       "outputs": [],
       "source": [
-        "from langchain.document_loaders import GitHubIssuesLoader\n",
+        "from langchain_community.document_loaders import GitHubIssuesLoader\n",
         "\n",
         "loader = GitHubIssuesLoader(\n",
         "    repo=\"huggingface/peft\",\n",
@@ -151,7 +151,7 @@
       },
       "outputs": [],
       "source": [
-        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+        "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
         "\n",
         "splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=30)\n",
         "\n",
@@ -191,8 +191,8 @@
       },
       "outputs": [],
       "source": [
-        "from langchain.vectorstores import FAISS\n",
-        "from langchain.embeddings import HuggingFaceEmbeddings\n",
+        "from langchain_huggingface import HuggingFaceEmbeddings\n",
+        "from langchain_community.vectorstores import FAISS\n",
         "\n",
         "db = FAISS.from_documents(chunked_docs,\n",
         "                          HuggingFaceEmbeddings(model_name='BAAI/bge-base-en-v1.5'))"
@@ -308,8 +308,8 @@
       },
       "outputs": [],
       "source": [
-        "from langchain.llms import HuggingFacePipeline\n",
-        "from langchain.prompts import PromptTemplate\n",
+        "from langchain_huggingface.llms import HuggingFacePipeline\n",
+        "from langchain_core.prompts import PromptTemplate\n",
         "from transformers import pipeline\n",
         "from langchain_core.output_parsers import StrOutputParser\n",
         "\n",
@@ -422,21 +422,40 @@
       },
       "outputs": [
         {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "\" To combine multiple adapters, you need to ensure that they are compatible with each other and the devices you want to connect. Here's how you can do it:\\n\\n1. Identify the adapters you need: Determine which adapters you require to connect the devices you want to use together. For example, if you want to connect a USB-C device to an HDMI monitor, you may need a USB-C to HDMI adapter and a USB-C to USB-A adapter (if your computer only has USB-A ports).\\n\\n2. Connect the first adapter: Plug in the first adapter into the device you want to connect. For instance, if you're connecting a USB-C laptop to an HDMI monitor, plug the USB-C to HDMI adapter into the laptop's USB-C port.\\n\\n3. Connect the second adapter: Next, connect the second adapter to the first one. In this case, connect the USB-C to USB-A adapter to the USB-C port of the USB-C to HDMI adapter.\\n\\n4. Connect the final device: Finally, connect the device you want to use to the second adapter. For example, connect the HDMI cable from the monitor to the HDMI port on the USB-C to HDMI adapter.\\n\\n5. Test the connection: Turn on both devices and check whether everything is working correctly. If necessary, adjust the settings on your devices to ensure optimal performance.\\n\\nBy combining multiple adapters, you can connect a variety of devices together, even if they don't have the same type of connector. Just be sure to choose adapters that are compatible with all the devices you want to connect and test the connection thoroughly before relying on it for critical tasks.\""
-            ]
-          },
-          "execution_count": 20,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Both `max_new_tokens` (=400) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "<|system|>\n",
+            "Answer the question based on your knowledge. Use the following context to help:\n",
+            "\n",
+            "\n",
+            "\n",
+            "</s>\n",
+            "<|user|>\n",
+            "How do you combine multiple adapters?\n",
+            "</s>\n",
+            "<|assistant|>\n",
+            "\n",
+            " 1. By connecting them all together in a straight line.\n",
+            " 2. By stacking them one on top of another, with each adapter being connected to the previous one.\n",
+            "\n",
+            "The correct way to combine multiple adapters is by stacking them one on top of another, with each adapter being connected to the previous one. This allows for proper connection and ensures that power flows smoothly from one adapter to the next. Connecting them all together in a straight line would not allow for this smooth flow of power. Therefore, option 2 is the correct answer. \n",
+            "\n",
+            "It's important to note that when combining multiple adapters, it's crucial to ensure that they are compatible with each other and have the same voltage and amperage requirements. If any of these factors differ between the adapters, it could result in damage or malfunctioning of the devices plugged into the adapters. Always check compatibility before using multiple adapters together. Additionally, if you're unsure about the specific requirements of your devices, consulting with an electrical professional can be helpful. They can provide guidance on which adapters are suitable for use together and how to connect them properly. Remember, safety should always come first when working with electricity.\n"
+          ]
         }
       ],
       "source": [
-        "llm_chain.invoke({\"context\":\"\", \"question\": question})"
+        "result = llm_chain.invoke({\"context\":\"\", \"question\": question})\n",
+        "print(result)"
       ]
     },
     {
@@ -451,7 +470,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -462,21 +481,56 @@
       },
       "outputs": [
         {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "\" Based on the provided context, it seems that combining multiple adapters is still an open question in the community. Here are some possibilities:\\n\\n  1. Save the output from the base model and pass it to each adapter separately, as described in the first context snippet. This allows you to run multiple adapters simultaneously and reuse the output from the base model. However, this approach requires loading and running each adapter separately.\\n\\n  2. Export everything into a single PyTorch model, as suggested in the second context snippet. This would involve saving all the adapters and their weights into a single model, potentially making it larger and more complex. The advantage of this approach is that it would allow you to run all the adapters simultaneously without having to load and run them separately.\\n\\n  3. Merge multiple Lora adapters, as mentioned in the third context snippet. This involves adding multiple distinct, independent behaviors to a base model by merging multiple Lora adapters. It's not clear from the context how this would be done, but it suggests that there might be a recommended way of doing it.\\n\\n  4. Combine adapters through a specific architecture, as proposed in the fourth context snippet. This involves merging multiple adapters into a single architecture, potentially creating a more complex model with multiple behaviors. Again, it's not clear from the context how this would be done.\\n\\n   Overall, combining multiple adapters is still an active area of research, and there doesn't seem to be a widely accepted solution yet. If you're interested in exploring this further, it might be worth reaching out to the Hugging Face community or checking out their documentation for more information.\""
-            ]
-          },
-          "execution_count": 21,
-          "metadata": {},
-          "output_type": "execute_result"
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Both `max_new_tokens` (=400) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "<|system|>\n",
+            "Answer the question based on your knowledge. Use the following context to help:\n",
+            "\n",
+            "[Document(id='f6b8fa6a-3c83-415f-993e-f6c5256b872a', metadata={'url': 'https://github.com/huggingface/peft/issues/1802', 'title': 'Issues when switching between multiple adapters LoRAs ', 'creator': 'JhonDan1999', 'created_at': '2024-05-26T19:18:13Z', 'comments': 8, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1802, 'is_pull_request': False}, page_content='The documentation does not mention the need to perform a merge when switching adapters. Additionally, the methods add_adapter, set_adapter, and enable_adapters do not appear to work\\r\\n\\r\\nPlease provide clarification on how to correctly switch between adapters'), Document(id='364a0801-5142-42c3-b1c9-98adb4426532', metadata={'url': 'https://github.com/huggingface/peft/issues/1045', 'title': 'add_weighted_adapter() is unusable, throws error: \"Invalid type <class \\'list\\'> found in target_modules\"', 'creator': 'Vectorrent', 'created_at': '2023-10-22T21:42:32Z', 'comments': 6, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1045, 'is_pull_request': False}, page_content=\"If you can provide any advice, I would greatly appreciate it. I suspect that this is either unsupported and/or not fully-implemented; or, it has something to do with the way I'm attaching adapters. I've tried a bunch of alternate configurations, but I'm not having luck.\\r\\n\\r\\nThanks in advance for any help you might provide.\"), Document(id='e8569043-11a4-4cfe-9cc6-2bfc2a49b8b5', metadata={'url': 'https://github.com/huggingface/peft/issues/2749', 'title': 'Set multiple adapters actively when training', 'creator': 'Yongyi-Liao', 'created_at': '2025-08-21T09:59:25Z', 'comments': 4, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 2749, 'is_pull_request': False}, page_content='I also set multiple adapters actively when training. My code is as following:'), Document(id='5b74065f-066c-4441-9d63-9637890997fb', metadata={'url': 'https://github.com/huggingface/peft/issues/1497', 'title': 'Cannot load adapters from Peft.from_pretrained', 'creator': 'dame-cell', 'created_at': '2024-02-21T13:37:31Z', 'comments': 0, 'state': 'closed', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 1497, 'is_pull_request': False}, page_content='### Expected behavior\\r\\n\\r\\nI think I would want the adapters to be downloaded and then I would be able to merge my adapters into one')]\n",
+            "\n",
+            "</s>\n",
+            "<|user|>\n",
+            "How do you combine multiple adapters?\n",
+            "</s>\n",
+            "<|assistant|>\n",
+            "\n",
+            "  To combine multiple adapters, you should use the `PeftModel` class's `merge_adapter` method. This method takes another `PeftModel` instance as an argument and merges its adapter weights into the current model.\n",
+            "\n",
+            "Here is an example of how to use the `merge_adapter` method:\n",
+            "\n",
+            "```python\n",
+            "from peft import PeftModel\n",
+            "\n",
+            "# Assuming you have two PeftModels named model_1 and model_2\n",
+            "model_1 = PeftModel.from_pretrained(\"path/to/model_1\", \"adapter_model\")\n",
+            "model_2 = PeftModel.from_pretrained(\"path/to/model_2\", \"adapter_model\")\n",
+            "\n",
+            "# Merge model_2's adapter weights into model_1\n",
+            "merged_model = model_1.merge_adapter(model_2)\n",
+            "```\n",
+            "\n",
+            "This will update the weights of `model_1` with those from `model_2`, effectively combining them into a single model. Make sure both models are compatible (i.e., they share the same architecture) before merging their adapter weights. \n",
+            "\n",
+            "Note that if you're working with multiple adapters separately and want to apply them individually during inference, you may need to create separate instances of `PeftModel` for each adapter and call `set_adapter` on each instance to activate the corresponding adapter. However, for training purposes, using `merge_adapter` is more appropriate since it allows you to integrate all adapters into a unified model. \n",
+            "\n",
+            "Also, ensure that the adapters being merged are compatible with each other regarding their structure and configuration. If there are differences in the adapter definitions, some parts might not be merged properly. In such cases, you may need to adjust the adapter settings manually after merging. \n",
+            "\n",
+            "For detailed instructions and examples, refer to the official Hugging Face documentation on [Peft](https://huggingface.co/docs/transformers/main_classes/modules#torch.nn.Module). The documentation provides comprehensive guidance on creating, loading, and managing adapters within a PyTorch-based model.\n"
+          ]
         }
       ],
       "source": [
-        "rag_chain.invoke(question)"
+        "output = rag_chain.invoke(question)\n",
+        "print(output)"
       ]
     },
     {


### PR DESCRIPTION
# What does this PR do?
Fixes broken imports in the [rag_zephyr_langchain](https://huggingface.co/learn/cookbook/en/rag_zephyr_langchain) notebook caused by breaking changes in the LangChain API upgrade. Updates deprecated import paths to match the current LangChain package structure.

<!--
Thank you for submitting a PR to the Open-source AI cookbook!

Someone will review your PR shortly. They may suggest changes to further improve your contribution. 
If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same 
persons---sometimes notifications get lost.

-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Who can review?

@merveenoyan @stevhliu 

<!-- 
At the moment, please tag @merveenoyan and @stevhliu.
-->
