### PR TITLE
feat: add free-web-search-ultimate notebook — zero-cost web search with HF models (v13.0.0)

### DIFF
--- a/notebooks/free_web_search/free_web_search_with_hf_models.ipynb
+++ b/notebooks/free_web_search/free_web_search_with_hf_models.ipynb
@@ -1,0 +1,42 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Free Web Search with HF Models (v13.0.0)\n\nZero-cost, API-key-free web search using [`free-web-search-ultimate`](https://github.com/wd041216-bit/free-web-search-ultimate).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install free-web-search-ultimate==13.0.0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from free_web_search_ultimate import UltimateSearcher\nsearcher = UltimateSearcher()\nresults = searcher.search('Hugging Face latest models 2025', engine='duckduckgo', max_results=5)\nfor r in results:\n    print(f\"Title: {r['title']}\\nURL: {r['url']}\\n\")\n"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds **free-web-search-ultimate** (v13.0.0) notebook — zero-cost, API-key-free web search for HF models.

- No API key required
- Supports DuckDuckGo, Bing, Google, Brave, Yahoo

**Install:** `pip install free-web-search-ultimate==13.0.0`
**PyPI:** https://pypi.org/project/free-web-search-ultimate/
**GitHub:** https://github.com/wd041216-bit/free-web-search-ultimate