### PR TITLE
Fix TRL GRPO VLM example link

### DIFF
--- a/notebooks/en/fine_tuning_vlm_grpo_trl.ipynb
+++ b/notebooks/en/fine_tuning_vlm_grpo_trl.ipynb
@@ -1313,7 +1313,7 @@
     "\n",
     "* [`Post training an LLM for reasoning with GRPO in TRL` recipe and the linked resources that it includes](https://huggingface.co/learn/cookbook/fine_tuning_llm_grpo_trl)\n",
     "* [GLM-4.1V-9B-Thinking paper](https://huggingface.co/papers/2507.01006)\n",
-    "* [TRL GRPO for VLMs example](https://github.com/huggingface/trl/examples/scripts/grpo_vlm.py)"
+    "* [TRL GRPO for VLMs example](https://github.com/huggingface/trl/blob/main/examples/grpo_visual_math/grpo_vlm.py)"
    ],
    "metadata": {
     "id": "0ygZdJJZL8ts"

--- a/notebooks/en/fine_tuning_vlm_grpo_trl.ipynb
+++ b/notebooks/en/fine_tuning_vlm_grpo_trl.ipynb
@@ -1313,7 +1313,7 @@
     "\n",
     "* [`Post training an LLM for reasoning with GRPO in TRL` recipe and the linked resources that it includes](https://huggingface.co/learn/cookbook/fine_tuning_llm_grpo_trl)\n",
     "* [GLM-4.1V-9B-Thinking paper](https://huggingface.co/papers/2507.01006)\n",
-    "* [TRL GRPO for VLMs example](https://github.com/huggingface/trl/blob/main/examples/grpo_visual_math/grpo_vlm.py)"
+    "* [TRL GRPO for VLMs example](https://github.com/huggingface/trl/blob/main/examples/grpo_visual_math/grpo_visual_math.py)"
    ],
    "metadata": {
     "id": "0ygZdJJZL8ts"


### PR DESCRIPTION
Follow-up to huggingface/trl#6820: TRL's `examples/` was reorganized into self-contained per-example folders, so links to the old `examples/scripts/...` paths will 404 once it merges. This updates them to the new locations. The link was also missing `/blob/main`, so it was already broken.