### PR TITLE
Bump doc-builder workflow SHA so main docs sync to the serving bucket

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@cf20b09f274383f0d91a7055c5e43f0a2ab3d1a3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: cookbook

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@cf20b09f274383f0d91a7055c5e43f0a2ab3d1a3  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
## Why

Docs builds on `main` have been green since April but nothing merged after 2026-04-08 shows up on https://huggingface.co/learn/cookbook (e.g. the Wordle GRPO recipe from #362 and the Turkish translation from #259 are both missing).

Since 2026-04-14 the Hub serves docs from the `hf-doc-build/doc` bucket instead of the `hf-doc-build/doc-build` dataset. doc-builder added a "Sync to bucket" step to `build_main_documentation.yml` on 2026-04-15/17 (huggingface/doc-builder#780, #782), but this repo is still pinned to `90b4ee2c` (2026-04-01), which only pushes the legacy `main.zip`. The bucket for `cookbook/main/**` is therefore frozen at the 2026-04-08 build.

## What

Bump the pinned doc-builder SHA in `build_documentation.yml` and `build_pr_documentation.yml` to current `main` (`cf20b09f`, 2026-09-08), which includes the bucket sync. `upload_pr_documentation.yml` was already bumped in #355.

Merging this triggers the main docs build (the workflow's `paths` includes its own file), which should publish everything pending since April.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
